### PR TITLE
Replace emoji icons with Ionicons

### DIFF
--- a/app/_layout.js
+++ b/app/_layout.js
@@ -2,6 +2,7 @@
 import { Stack } from 'expo-router';
 import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { ThemeProvider, useTheme } from '../src/context/ThemeContext';
 
 function RootLayoutNav() {
@@ -28,7 +29,7 @@ function RootLayoutNav() {
               style={{ marginRight: 15 }}
               testID="settings-button"
             >
-              <Text style={{ color: '#FFFFFF', fontSize: 16 }}>⚙️</Text>
+              <Ionicons name="settings" size={20} color="#FFFFFF" />
             </TouchableOpacity>
           ),
         }}

--- a/app/detail.js
+++ b/app/detail.js
@@ -10,6 +10,7 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import ConfirmationModal from '../src/components/ConfirmationModal';
 import DatePickerModal from '../src/components/DatePickerModal';
 import ToastNotification from '../src/components/ToastNotification';
@@ -289,7 +290,7 @@ export default function DetailScreen() {
                                 onPress={handleImagePicker}
                                 activeOpacity={0.7}
                             >
-                                <Text style={styles.photoButtonText}>📷</Text>
+                            <Ionicons name="camera" style={styles.photoButtonText} />
                             </TouchableOpacity>
                         </View>
                     ) : (
@@ -298,7 +299,7 @@ export default function DetailScreen() {
                             onPress={handleImagePicker}
                             activeOpacity={0.7}
                         >
-                            <Text style={styles.photoPlaceholderIcon}>📷</Text>
+                            <Ionicons name="camera" style={styles.photoPlaceholderIcon} />
                             <Text style={styles.photoPlaceholderText}>Add Photo</Text>
                         </TouchableOpacity>
                     )}
@@ -352,7 +353,7 @@ export default function DetailScreen() {
                         <Text style={styles.dateButtonText}>
                             {formatDateForDisplay(crime.date)}
                         </Text>
-                        <Text style={styles.dateButtonIcon}>📅</Text>
+                        <Ionicons name="calendar" style={styles.dateButtonIcon} />
                     </TouchableOpacity>
                 </View>
 
@@ -365,7 +366,7 @@ export default function DetailScreen() {
                     >
                         <View style={[styles.checkbox, crime.solved && styles.checkboxChecked]}>
                             {crime.solved && (
-                                <Text style={styles.checkmarkText}>✓</Text>
+                                <Ionicons name="checkmark-circle" style={styles.checkmarkText} />
                             )}
                         </View>
                         <Text style={styles.checkboxLabel}>Solved</Text>

--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,7 @@
 import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useCallback, useState } from 'react';
 import { FlatList, RefreshControl, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import CrimeListItem from '../src/components/CrimeListItem';
 import EmptyState from '../src/components/EmptyState';
 import { useTheme } from '../src/context/ThemeContext';
@@ -88,7 +89,7 @@ export default function IndexScreen() {
                 onPress={handleAddCrime}
                 testID="add-crime-button"
             >
-                <Text style={{ color: '#FFFFFF', fontSize: 24, fontWeight: 'bold' }}>+</Text>
+                <Ionicons name="add" size={28} color="#FFFFFF" />
             </TouchableOpacity>
 
             <FlatList


### PR DESCRIPTION
## Summary
- import Ionicons from `@expo/vector-icons`
- swap emoji icons for Ionicons across the app

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: Invalid package name; network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6876fc1f88648330b619e453a8f897c4