### PR TITLE
Refactor to Pressable

### DIFF
--- a/app/_layout.js
+++ b/app/_layout.js
@@ -1,7 +1,7 @@
 // app/_layout.js - Root Layout for Expo Router
 import { Stack } from 'expo-router';
 import React from 'react';
-import { Text, TouchableOpacity } from 'react-native';
+import { Text, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { ThemeProvider, useTheme } from '../src/context/ThemeContext';
 
@@ -25,12 +25,12 @@ function RootLayoutNav() {
         options={{
           title: 'Criminal Intent',
           headerRight: () => (
-            <TouchableOpacity
+            <Pressable
               style={{ marginRight: 15 }}
               testID="settings-button"
             >
               <Ionicons name="settings" size={20} color="#FFFFFF" />
-            </TouchableOpacity>
+            </Pressable>
           ),
         }}
       />

--- a/app/detail.js
+++ b/app/detail.js
@@ -7,7 +7,7 @@ import {
     ScrollView,
     Text,
     TextInput,
-    TouchableOpacity,
+    Pressable,
     View
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -285,23 +285,27 @@ export default function DetailScreen() {
                     {crime.photoUri ? (
                         <View style={styles.photoContainer}>
                             <Image source={{ uri: crime.photoUri }} style={styles.photo} />
-                            <TouchableOpacity
-                                style={styles.photoButton}
+                            <Pressable
                                 onPress={handleImagePicker}
-                                activeOpacity={0.7}
+                                style={({ pressed }) => [
+                                    styles.photoButton,
+                                    pressed && { opacity: 0.7 },
+                                ]}
                             >
                             <Ionicons name="camera" style={styles.photoButtonText} />
-                            </TouchableOpacity>
+                            </Pressable>
                         </View>
                     ) : (
-                        <TouchableOpacity
-                            style={styles.photoPlaceholder}
+                        <Pressable
                             onPress={handleImagePicker}
-                            activeOpacity={0.7}
+                            style={({ pressed }) => [
+                                styles.photoPlaceholder,
+                                pressed && { opacity: 0.7 },
+                            ]}
                         >
                             <Ionicons name="camera" style={styles.photoPlaceholderIcon} />
                             <Text style={styles.photoPlaceholderText}>Add Photo</Text>
-                        </TouchableOpacity>
+                        </Pressable>
                     )}
                 </View>
 
@@ -345,24 +349,28 @@ export default function DetailScreen() {
 
                 {/* Date Section */}
                 <View style={styles.section}>
-                    <TouchableOpacity
-                        style={styles.dateButton}
+                    <Pressable
                         onPress={() => setShowDatePicker(true)}
-                        activeOpacity={0.7}
+                        style={({ pressed }) => [
+                            styles.dateButton,
+                            pressed && { opacity: 0.7 },
+                        ]}
                     >
                         <Text style={styles.dateButtonText}>
                             {formatDateForDisplay(crime.date)}
                         </Text>
                         <Ionicons name="calendar" style={styles.dateButtonIcon} />
-                    </TouchableOpacity>
+                    </Pressable>
                 </View>
 
                 {/* Solved Checkbox */}
                 <View style={styles.section}>
-                    <TouchableOpacity
-                        style={styles.checkboxRow}
+                    <Pressable
                         onPress={handleSolvedToggle}
-                        activeOpacity={0.7}
+                        style={({ pressed }) => [
+                            styles.checkboxRow,
+                            pressed && { opacity: 0.7 },
+                        ]}
                     >
                         <View style={[styles.checkbox, crime.solved && styles.checkboxChecked]}>
                             {crime.solved && (
@@ -370,34 +378,39 @@ export default function DetailScreen() {
                             )}
                         </View>
                         <Text style={styles.checkboxLabel}>Solved</Text>
-                    </TouchableOpacity>
+                    </Pressable>
                 </View>
 
                 {/* Save Button */}
-                <TouchableOpacity
-                    style={[globalStyles.button, styles.saveButton]}
+                <Pressable
                     onPress={handleSave}
                     disabled={isSaving || isDeleting}
-                    activeOpacity={0.8}
                     testID="save-button"
+                    style={({ pressed }) => [
+                        globalStyles.button,
+                        styles.saveButton,
+                        pressed && { opacity: 0.8 },
+                    ]}
                 >
                     <Text style={globalStyles.buttonText}>
                         {isSaving ? 'Saving...' : 'Save'}
                     </Text>
-                </TouchableOpacity>
+                </Pressable>
 
                 {/* Delete Button - Only show for existing crimes */}
                 {isExistingCrime && (
-                    <TouchableOpacity
-                        style={[styles.deleteButton]}
+                    <Pressable
                         onPress={handleDelete}
                         disabled={isSaving || isDeleting}
-                        activeOpacity={0.8}
+                        style={({ pressed }) => [
+                            styles.deleteButton,
+                            pressed && { opacity: 0.8 },
+                        ]}
                     >
                         <Text style={styles.deleteButtonText}>
                             {isDeleting ? 'Deleting...' : 'DELETE CRIME'}
                         </Text>
-                    </TouchableOpacity>
+                    </Pressable>
                 )}
             </ScrollView>
 

--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,7 @@
 // app/index.js - Main Screen using Expo Router
 import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useCallback, useState } from 'react';
-import { FlatList, RefreshControl, Text, TouchableOpacity, View } from 'react-native';
+import { FlatList, RefreshControl, Text, Pressable, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import CrimeListItem from '../src/components/CrimeListItem';
 import EmptyState from '../src/components/EmptyState';
@@ -68,7 +68,7 @@ export default function IndexScreen() {
     return (
         <View style={[globalStyles.container]}>
             {/* Add Crime Button - Fixed Position */}
-            <TouchableOpacity
+            <Pressable
                 style={{
                     position: 'absolute',
                     top: 20,
@@ -90,7 +90,7 @@ export default function IndexScreen() {
                 testID="add-crime-button"
             >
                 <Ionicons name="add" size={28} color="#FFFFFF" />
-            </TouchableOpacity>
+            </Pressable>
 
             <FlatList
                 data={crimes}

--- a/src/components/CrimeListItem.js
+++ b/src/components/CrimeListItem.js
@@ -1,6 +1,6 @@
 // src/components/CrimeListItem.js
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../context/ThemeContext';
 import { createCrimeItemStyles } from '../styles/components/crimeItemStyles';
@@ -28,10 +28,13 @@ export default function CrimeListItem({ crime, onPress }) {
     };
 
     return (
-        <TouchableOpacity
-            style={[globalStyles.listItem, styles.container]}
+        <Pressable
             onPress={onPress}
-            activeOpacity={0.7}
+            style={({ pressed }) => [
+                globalStyles.listItem,
+                styles.container,
+                pressed && { opacity: 0.7 },
+            ]}
         >
             <View style={styles.content}>
                 <View style={styles.header}>
@@ -70,6 +73,6 @@ export default function CrimeListItem({ crime, onPress }) {
                     color={theme.colors.textSecondary}
                 />
             </View>
-        </TouchableOpacity>
+        </Pressable>
     );
 }

--- a/src/components/DatePickerModal.js
+++ b/src/components/DatePickerModal.js
@@ -2,11 +2,11 @@
 // src/components/DatePickerModal.js - No Icons Version
 import DateTimePicker from '@react-native-community/datetimepicker';
 import React, { useEffect, useState } from 'react';
-import { Modal, Platform, Text, TouchableOpacity, View } from 'react-native';
+import { Modal, Platform, Text, Pressable, View } from 'react-native';
 
 // src/components/DatePickerModal.js
 import React from 'react';
-import { View, Text, Modal, TouchableOpacity, Platform } from 'react-native';
+import { View, Text, Modal, Pressable, Platform } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 
 import { useTheme } from '../context/ThemeContext';
@@ -71,21 +71,27 @@ export default function DatePickerModal({ visible, date, onDateChange, onCancel 
                     />
 
                     <View style={styles.buttonRow}>
-                        <TouchableOpacity
-                            style={[styles.button, styles.cancelButton]}
+                        <Pressable
                             onPress={onCancel}
-                            activeOpacity={0.7}
+                            style={({ pressed }) => [
+                                styles.button,
+                                styles.cancelButton,
+                                pressed && { opacity: 0.7 },
+                            ]}
                         >
                             <Text style={styles.cancelButtonText}>Cancel</Text>
-                        </TouchableOpacity>
+                        </Pressable>
 
-                        <TouchableOpacity
-                            style={[styles.button, styles.okButton]}
+                        <Pressable
                             onPress={() => onDateChange(selectedDate)}
-                            activeOpacity={0.7}
+                            style={({ pressed }) => [
+                                styles.button,
+                                styles.okButton,
+                                pressed && { opacity: 0.7 },
+                            ]}
                         >
                             <Text style={styles.okButtonText}>OK</Text>
-                        </TouchableOpacity>
+                        </Pressable>
                     </View>
                 </View>
             </View>

--- a/src/components/EmptyState.js
+++ b/src/components/EmptyState.js
@@ -1,6 +1,6 @@
 // src/components/EmptyState.js
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../context/ThemeContext';
 import { createEmptyStateStyles } from '../styles/components/emptyStateStyles';
@@ -33,15 +33,18 @@ export default function EmptyState({
             </Text>
 
             {onAction && actionText && (
-                <TouchableOpacity
-                    style={[globalStyles.button, styles.actionButton]}
+                <Pressable
                     onPress={onAction}
-                    activeOpacity={0.8}
+                    style={({ pressed }) => [
+                        globalStyles.button,
+                        styles.actionButton,
+                        pressed && { opacity: 0.8 },
+                    ]}
                 >
                     <Text style={globalStyles.buttonText}>
                         {actionText}
                     </Text>
-                </TouchableOpacity>
+                </Pressable>
             )}
         </View>
     );

--- a/src/components/ThemeSelector.js
+++ b/src/components/ThemeSelector.js
@@ -1,6 +1,6 @@
 // src/components/ThemeSelector.js
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../context/ThemeContext';
 import { createThemeSelectorStyles } from '../styles/components/themeSelectorStyles';
@@ -17,11 +17,14 @@ export default function ThemeSelector() {
         const isSelected = themeName === themeKey;
 
         return (
-            <TouchableOpacity
+            <Pressable
                 key={themeKey}
-                style={[styles.themeOption, isSelected && styles.themeOptionSelected]}
                 onPress={() => handleThemeChange(themeKey)}
-                activeOpacity={0.7}
+                style={({ pressed }) => [
+                    styles.themeOption,
+                    isSelected && styles.themeOptionSelected,
+                    pressed && { opacity: 0.7 },
+                ]}
             >
                 <View style={styles.themeInfo}>
                     <View style={styles.themeHeader}>
@@ -67,7 +70,7 @@ export default function ThemeSelector() {
                         style={styles.checkIcon}
                     />
                 )}
-            </TouchableOpacity>
+            </Pressable>
         );
     };
 


### PR DESCRIPTION
## Summary
- replace `TouchableOpacity` with `Pressable`
- adapt `activeOpacity` uses to `pressed` style callbacks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68771951e9008330a84e781f607a200e